### PR TITLE
Fix typo in URL for this repo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup (
   packages=['image_datasets'],
   keywords = ['computer-vision', 'machine-learning', 'datasets'],
   description='Image datasets for computer vision projects',
-  url='https://github.com/yale-dhlab/image_datasets',
+  url='https://github.com/yaledhlab/image_datasets',
   author='Douglas Duhaime',
   author_email='douglas.duhaime@gmail.com',
   license='MIT',


### PR DESCRIPTION
This will make it a bit easier for someone who sees image_datasets in the wild to track it to Github.